### PR TITLE
Add external_script auth type for custom credential providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Transparent authentication injection proxy for AI agents.**
 
-cred-proxy is a [mitmproxy](https://mitmproxy.org/)-based proxy that sits between your AI agent and external APIs. It automatically injects authentication credentials into outbound HTTP requests so agents never handle secrets directly. Supports bearer tokens, basic auth, custom headers, query parameters, and OAuth2 client credentials.
+cred-proxy is a [mitmproxy](https://mitmproxy.org/)-based proxy that sits between your AI agent and external APIs. It automatically injects authentication credentials into outbound HTTP requests so agents never handle secrets directly. Supports bearer tokens, basic auth, custom headers, query parameters, OAuth2 client credentials, and external credential scripts.
 
 ```mermaid
 flowchart LR
@@ -84,7 +84,7 @@ The agent polls for status; once a user fills in the form, the credential is liv
 | Page | Description |
 |------|-------------|
 | [Getting Started](docs/getting-started.md) | Install, configure, and run |
-| [Configuration](docs/configuration.md) | YAML reference, all 5 auth types, domain matching |
+| [Configuration](docs/configuration.md) | YAML reference, all 6 auth types, domain matching |
 | [Architecture](docs/architecture.md) | Component design, request lifecycle, security model |
 | [Management API](docs/api/management.md) | REST API for credential CRUD and status |
 | [Agent API](docs/api/agent.md) | In-band `/__auth/*` endpoints for agents |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -54,3 +54,16 @@ credentials:
   #     scopes:
   #       - "read"
   #       - "write"
+
+  # External script example (e.g. GitHub App installation token)
+  # - id: "github-app"
+  #   domain: "api.github.com"
+  #   enabled: true
+  #   auth:
+  #     type: external_script
+  #     script: "./scripts/github-app-token.sh"
+  #     env:
+  #       GITHUB_APP_ID: "12345"
+  #       GITHUB_PRIVATE_KEY_PATH: "/path/to/key.pem"
+  #       GITHUB_INSTALLATION_ID: "67890"
+  #     refresh_interval: 600

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,6 +176,52 @@ Obtains an access token from an OAuth2 token endpoint using the client credentia
     | `client_secret` | string | Client secret |
     | `scopes` | list[string] | OAuth2 scopes (optional, default: `[]`) |
 
+### External Script
+
+Delegates credential acquisition to any executable script. The script outputs JSON with headers to inject. This enables GitHub App tokens, custom vault integrations, and any other bespoke credential rotation.
+
+=== "YAML"
+
+    ```yaml
+    auth:
+      type: external_script
+      script: "./scripts/github-app-token.sh"
+      env:
+        GITHUB_APP_ID: "12345"
+        GITHUB_PRIVATE_KEY_PATH: "/path/to/key.pem"
+        GITHUB_INSTALLATION_ID: "67890"
+      refresh_interval: 600
+    ```
+
+=== "Fields"
+
+    | Field | Type | Description |
+    |-------|------|-------------|
+    | `type` | `"external_script"` | Auth type discriminator |
+    | `script` | string | Path to executable, resolved relative to config file directory |
+    | `env` | dict[string, string] | Environment variables passed to the script (optional, default: `{}`) |
+    | `refresh_interval` | int | Seconds between re-runs (optional, default: `3600`) |
+
+**Script contract:**
+
+The script receives configured `env` vars and must output JSON to stdout:
+
+```json
+{
+  "headers": {
+    "Authorization": "Bearer ghp_abc123",
+    "X-Custom": "value"
+  },
+  "refresh_in": 300
+}
+```
+
+- `headers` (required): Dict of header-name → header-value to inject into proxied requests
+- `refresh_in` (optional): Override `refresh_interval` for this specific result
+- Non-zero exit code = failure (logged, request passes through unauthenticated, stale cache evicted)
+- Stderr is logged but otherwise ignored
+- Script execution timeout: 30 seconds
+
 ## Hot-Reload
 
 cred-proxy watches the credentials YAML file for changes using filesystem events (via [watchfiles](https://watchfiles.helpmanual.io/)). When the file is modified:

--- a/src/auth_injection_proxy/addon.py
+++ b/src/auth_injection_proxy/addon.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from pathlib import Path
 from typing import Any
 
 import uvicorn
@@ -12,6 +13,7 @@ from mitmproxy import ctx, http
 
 from auth_injection_proxy.agent_api.handlers import AgentApiHandler
 from auth_injection_proxy.config import AppConfig, load_config
+from auth_injection_proxy.injection.external_script import ExternalScriptManager
 from auth_injection_proxy.injection.injector import inject_auth
 from auth_injection_proxy.injection.oauth2 import OAuth2TokenManager
 from auth_injection_proxy.logging import setup_logging
@@ -30,6 +32,8 @@ class AuthInjectionAddon:
     def __init__(self) -> None:
         self._matcher = RuleMatcher()
         self._oauth2 = OAuth2TokenManager()
+        self._external_script = ExternalScriptManager()
+        self._config_dir: str = "."
         self._store: YamlCredentialStore | None = None
         self._pending: PendingRequestStore | None = None
         self._agent_api: AgentApiHandler | None = None
@@ -51,6 +55,7 @@ class AuthInjectionAddon:
             return
 
         config_path = ctx.options.config_path
+        self._config_dir = str(Path(config_path).resolve().parent)
         setup_logging()
 
         try:
@@ -89,6 +94,7 @@ class AuthInjectionAddon:
     def _on_rules_changed(self, rules: list) -> None:
         self._matcher.update_rules(rules)
         self._oauth2.clear()
+        self._external_script.clear()
         logger.info("Rules reloaded: %d rules active", len(rules))
 
     async def request(self, flow: http.HTTPFlow) -> None:
@@ -119,7 +125,9 @@ class AuthInjectionAddon:
             return
 
         # Inject auth
-        secrets_list = await inject_auth(flow, rule, self._oauth2)
+        secrets_list = await inject_auth(
+            flow, rule, self._oauth2, self._external_script, self._config_dir
+        )
         if secrets_list:
             self._injected_secrets[id(flow)] = secrets_list
 

--- a/src/auth_injection_proxy/injection/external_script.py
+++ b/src/auth_injection_proxy/injection/external_script.py
@@ -1,0 +1,160 @@
+"""External script credential provider with caching and locking."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+
+from mitmproxy import http
+
+logger = logging.getLogger(__name__)
+
+_SCRIPT_TIMEOUT = 30  # seconds
+
+
+class _CachedResult:
+    __slots__ = ("headers", "expires_at")
+
+    def __init__(self, headers: dict[str, str], expires_at: float) -> None:
+        self.headers = headers
+        self.expires_at = expires_at
+
+    def is_valid(self) -> bool:
+        return time.monotonic() < self.expires_at
+
+
+class ExternalScriptManager:
+    """Manages credentials obtained from external scripts with per-rule locking."""
+
+    def __init__(self) -> None:
+        self._cache: dict[str, _CachedResult] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _get_lock(self, rule_id: str) -> asyncio.Lock:
+        if rule_id not in self._locks:
+            self._locks[rule_id] = asyncio.Lock()
+        return self._locks[rule_id]
+
+    async def inject(
+        self,
+        flow: http.HTTPFlow,
+        rule_id: str,
+        script: str,
+        env: dict[str, str],
+        refresh_interval: int,
+        config_dir: str,
+    ) -> list[str]:
+        """Run script (cached), inject headers into flow. Returns secret values."""
+        cached = self._cache.get(rule_id)
+        if cached and cached.is_valid():
+            return self._apply_headers(flow, cached.headers)
+
+        lock = self._get_lock(rule_id)
+        async with lock:
+            # Double-check after acquiring lock
+            cached = self._cache.get(rule_id)
+            if cached and cached.is_valid():
+                return self._apply_headers(flow, cached.headers)
+
+            result = await self._run_script(rule_id, script, env, refresh_interval, config_dir)
+            if result is None:
+                return []
+            return self._apply_headers(flow, result.headers)
+
+    async def _run_script(
+        self,
+        rule_id: str,
+        script: str,
+        env: dict[str, str],
+        refresh_interval: int,
+        config_dir: str,
+    ) -> _CachedResult | None:
+        if os.path.isabs(script):
+            script_path = script
+        else:
+            script_path = os.path.normpath(os.path.join(config_dir, script))
+
+        # Build env: inherit current env + configured vars
+        proc_env = dict(os.environ)
+        proc_env.update(env)
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                script_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=proc_env,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=_SCRIPT_TIMEOUT)
+        except TimeoutError:
+            logger.error("External script timed out for rule %s: %s", rule_id, script_path)
+            self._cache.pop(rule_id, None)
+            return None
+        except Exception:
+            logger.exception("External script failed to execute for rule %s", rule_id)
+            self._cache.pop(rule_id, None)
+            return None
+
+        if stderr:
+            stderr_text = stderr.decode(errors="replace")
+            logger.debug("External script stderr for rule %s: %s", rule_id, stderr_text)
+
+        if proc.returncode != 0:
+            logger.error(
+                "External script exited %d for rule %s: %s",
+                proc.returncode,
+                rule_id,
+                script_path,
+            )
+            self._cache.pop(rule_id, None)
+            return None
+
+        try:
+            data = json.loads(stdout)
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.error("External script output not valid JSON for rule %s: %s", rule_id, e)
+            self._cache.pop(rule_id, None)
+            return None
+
+        headers = data.get("headers")
+        if not isinstance(headers, dict):
+            logger.error("External script output missing 'headers' dict for rule %s", rule_id)
+            self._cache.pop(rule_id, None)
+            return None
+
+        refresh_in = data.get("refresh_in", refresh_interval)
+        try:
+            refresh_in = int(refresh_in)
+        except (TypeError, ValueError):
+            refresh_in = refresh_interval
+
+        # Shave 30s off TTL to avoid edge-of-expiry races (same as oauth2)
+        result = _CachedResult(
+            headers=headers,
+            expires_at=time.monotonic() + max(refresh_in - 30, 0),
+        )
+        self._cache[rule_id] = result
+        logger.info(
+            "External script credentials acquired for rule %s (refresh in %ds)",
+            rule_id,
+            refresh_in,
+        )
+        return result
+
+    def clear(self, rule_id: str | None = None) -> None:
+        """Clear cached results. If rule_id given, clear only that rule."""
+        if rule_id:
+            self._cache.pop(rule_id, None)
+        else:
+            self._cache.clear()
+
+    @staticmethod
+    def _apply_headers(flow: http.HTTPFlow, headers: dict[str, str]) -> list[str]:
+        secrets: list[str] = []
+        for name, value in headers.items():
+            flow.request.headers[name] = value
+            secrets.append(value)
+        return secrets

--- a/src/auth_injection_proxy/injection/injector.py
+++ b/src/auth_injection_proxy/injection/injector.py
@@ -6,6 +6,7 @@ from mitmproxy import http
 
 from auth_injection_proxy.injection.basic import inject_basic
 from auth_injection_proxy.injection.bearer import inject_bearer
+from auth_injection_proxy.injection.external_script import ExternalScriptManager
 from auth_injection_proxy.injection.header import inject_header
 from auth_injection_proxy.injection.oauth2 import OAuth2TokenManager
 from auth_injection_proxy.injection.query_param import inject_query_param
@@ -13,6 +14,7 @@ from auth_injection_proxy.matching.models import (
     BasicAuth,
     BearerAuth,
     CredentialRule,
+    ExternalScriptAuth,
     HeaderAuth,
     OAuth2ClientCredentialsAuth,
     QueryParamAuth,
@@ -23,6 +25,8 @@ async def inject_auth(
     flow: http.HTTPFlow,
     rule: CredentialRule,
     oauth2_manager: OAuth2TokenManager,
+    external_script_manager: ExternalScriptManager,
+    config_dir: str,
 ) -> list[str]:
     """Inject auth into the flow based on rule type. Returns injected secret values."""
     match rule.auth:
@@ -42,5 +46,9 @@ async def inject_auth(
         ):
             return await oauth2_manager.inject(
                 flow, rule.id, token_url, client_id, client_secret, scopes
+            )
+        case ExternalScriptAuth(script=script, env=env, refresh_interval=interval):
+            return await external_script_manager.inject(
+                flow, rule.id, script, env, interval, config_dir
             )
     return []

--- a/src/auth_injection_proxy/matching/models.py
+++ b/src/auth_injection_proxy/matching/models.py
@@ -38,6 +38,13 @@ class OAuth2ClientCredentialsAuth(BaseModel):
     scopes: list[str] = Field(default_factory=list)
 
 
+class ExternalScriptAuth(BaseModel):
+    type: Literal["external_script"]
+    script: str
+    env: dict[str, str] = Field(default_factory=dict)
+    refresh_interval: int = 3600
+
+
 AuthConfig = Annotated[
     Union[  # noqa: UP007 — required for Pydantic discriminator
         BearerAuth,
@@ -45,6 +52,7 @@ AuthConfig = Annotated[
         HeaderAuth,
         QueryParamAuth,
         OAuth2ClientCredentialsAuth,
+        ExternalScriptAuth,
     ],
     Field(discriminator="type"),
 ]

--- a/src/auth_injection_proxy/store/masking.py
+++ b/src/auth_injection_proxy/store/masking.py
@@ -6,6 +6,7 @@ from auth_injection_proxy.matching.models import (
     BasicAuth,
     BearerAuth,
     CredentialRule,
+    ExternalScriptAuth,
     HeaderAuth,
     OAuth2ClientCredentialsAuth,
     QueryParamAuth,
@@ -48,5 +49,7 @@ def mask_rule(rule: CredentialRule) -> dict:
         case OAuth2ClientCredentialsAuth():
             # AC-7.4: client_id and token_url shown, client_secret masked
             data["auth"]["client_secret"] = mask_secret(auth.client_secret)
+        case ExternalScriptAuth():
+            data["auth"]["env"] = {k: "***" for k in auth.env}
 
     return data

--- a/tests/integration/test_addon_flow.py
+++ b/tests/integration/test_addon_flow.py
@@ -2,6 +2,7 @@
 
 from mitmproxy import http
 
+from auth_injection_proxy.injection.external_script import ExternalScriptManager
 from auth_injection_proxy.injection.injector import inject_auth
 from auth_injection_proxy.injection.oauth2 import OAuth2TokenManager
 from auth_injection_proxy.matching.models import (
@@ -34,7 +35,7 @@ class TestFullRequestCycle:
         rule = matcher.match("api.openai.com", "/v1/chat")
         assert rule is not None
 
-        secrets = await inject_auth(flow, rule, oauth2)
+        secrets = await inject_auth(flow, rule, oauth2, ExternalScriptManager(), ".")
         assert flow.request.headers["Authorization"] == "Bearer sk-secret-123"
 
         # Simulate upstream echoing the secret
@@ -73,7 +74,7 @@ class TestFullRequestCycle:
         rule = matcher.match("jira.example.com", "/api/issues")
         assert rule is not None
 
-        secrets = await inject_auth(flow, rule, oauth2)
+        secrets = await inject_auth(flow, rule, oauth2, ExternalScriptManager(), ".")
         assert "Basic" in flow.request.headers["Authorization"]
         assert len(secrets) > 0
 
@@ -90,7 +91,7 @@ class TestFullRequestCycle:
 
         flow = make_flow("https://api.example.com/data")
         rule = matcher.match("api.example.com", "/data")
-        secrets = await inject_auth(flow, rule, oauth2)
+        secrets = await inject_auth(flow, rule, oauth2, ExternalScriptManager(), ".")
         assert flow.request.headers["X-API-Key"] == "key123"
 
         flow.response = http.Response.make(200, b"echoed key123 back")
@@ -110,7 +111,7 @@ class TestFullRequestCycle:
 
         flow = make_flow("https://legacy.example.com/api?page=1")
         rule = matcher.match("legacy.example.com", "/api")
-        secrets = await inject_auth(flow, rule, oauth2)
+        secrets = await inject_auth(flow, rule, oauth2, ExternalScriptManager(), ".")
         assert flow.request.query["api_key"] == "secret"
         assert flow.request.query["page"] == "1"
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -80,3 +80,43 @@ class TestLoadConfig:
         config = load_config(str(path))
         assert config.proxy.listen_port == 8080
         assert config.credentials == []
+
+    def test_external_script_auth_type(self, tmp_path):
+        """external_script auth type parses correctly."""
+        path = tmp_path / "config.yaml"
+        path.write_text("""credentials:
+  - id: "github-app"
+    domain: "api.github.com"
+    auth:
+      type: external_script
+      script: "./scripts/github-app-token.sh"
+      env:
+        GITHUB_APP_ID: "12345"
+        GITHUB_PRIVATE_KEY_PATH: "/path/to/key.pem"
+      refresh_interval: 600
+""")
+        config = load_config(str(path))
+        assert len(config.credentials) == 1
+        rule = config.credentials[0]
+        assert rule.auth.type == "external_script"
+        assert rule.auth.script == "./scripts/github-app-token.sh"
+        assert rule.auth.env == {
+            "GITHUB_APP_ID": "12345",
+            "GITHUB_PRIVATE_KEY_PATH": "/path/to/key.pem",
+        }
+        assert rule.auth.refresh_interval == 600
+
+    def test_external_script_defaults(self, tmp_path):
+        """external_script defaults: empty env, 3600 refresh."""
+        path = tmp_path / "config.yaml"
+        path.write_text("""credentials:
+  - id: "simple"
+    domain: "api.example.com"
+    auth:
+      type: external_script
+      script: "./token.sh"
+""")
+        config = load_config(str(path))
+        rule = config.credentials[0]
+        assert rule.auth.env == {}
+        assert rule.auth.refresh_interval == 3600

--- a/tests/unit/test_injection_external_script.py
+++ b/tests/unit/test_injection_external_script.py
@@ -1,0 +1,365 @@
+"""External script credential provider tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from auth_injection_proxy.injection.external_script import ExternalScriptManager
+from tests.conftest import make_flow
+
+
+def _make_proc_result(stdout: str = "", stderr: str = "", returncode: int = 0) -> AsyncMock:
+    """Create a mock completed process."""
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate = AsyncMock(return_value=(stdout.encode(), stderr.encode()))
+    return proc
+
+
+class TestExternalScriptManager:
+    @pytest.fixture
+    def manager(self) -> ExternalScriptManager:
+        return ExternalScriptManager()
+
+    async def test_successful_injection(self, manager: ExternalScriptManager):
+        """Script outputs headers → headers injected into flow."""
+        flow = make_flow("https://api.github.com/repos")
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer ghp_abc123"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            secrets = await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert flow.request.headers["Authorization"] == "Bearer ghp_abc123"
+        assert "Bearer ghp_abc123" in secrets
+
+    async def test_multiple_headers(self, manager: ExternalScriptManager):
+        """Script can inject multiple headers."""
+        flow = make_flow("https://api.example.com/data")
+        output = json.dumps(
+            {
+                "headers": {
+                    "Authorization": "Bearer tok",
+                    "X-Custom": "custom-val",
+                },
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            secrets = await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert flow.request.headers["Authorization"] == "Bearer tok"
+        assert flow.request.headers["X-Custom"] == "custom-val"
+        assert "Bearer tok" in secrets
+        assert "custom-val" in secrets
+
+    async def test_refresh_in_override(self, manager: ExternalScriptManager):
+        """Script outputs refresh_in → overrides default interval."""
+        flow = make_flow("https://api.github.com/repos")
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+                "refresh_in": 60,
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        cached = manager._cache.get("r1")
+        assert cached is not None
+        # refresh_in=60 minus 30s buffer = 30s from now
+        assert cached.expires_at <= time.monotonic() + 31
+
+    async def test_script_failure_returns_empty(self, manager: ExternalScriptManager):
+        """Non-zero exit code → empty secrets, no headers injected."""
+        flow = make_flow("https://api.github.com/repos")
+        proc = _make_proc_result(returncode=1, stderr="error occurred")
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            secrets = await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert secrets == []
+        assert "Authorization" not in flow.request.headers
+
+    async def test_script_timeout(self, manager: ExternalScriptManager):
+        """Script timeout → treated as failure."""
+        flow = make_flow("https://api.github.com/repos")
+
+        async def slow_communicate():
+            raise TimeoutError
+
+        proc = AsyncMock()
+        proc.communicate = slow_communicate
+
+        with (
+            patch(
+                "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+                return_value=proc,
+            ),
+            patch(
+                "auth_injection_proxy.injection.external_script.asyncio.wait_for",
+                side_effect=TimeoutError,
+            ),
+        ):
+            secrets = await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert secrets == []
+
+    async def test_caching(self, manager: ExternalScriptManager):
+        """Second call within interval reuses cached result."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer cached-tok"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+        call_count = 0
+
+        async def mock_create(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return proc
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            side_effect=mock_create,
+        ):
+            flow1 = make_flow("https://api.github.com/repos")
+            await manager.inject(flow1, "r1", "./script.sh", {}, 3600, "/config")
+            flow2 = make_flow("https://api.github.com/repos")
+            await manager.inject(flow2, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert call_count == 1
+        assert flow2.request.headers["Authorization"] == "Bearer cached-tok"
+
+    async def test_cache_expiry(self, manager: ExternalScriptManager):
+        """Call after expiry re-runs script."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+        call_count = 0
+
+        async def mock_create(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return proc
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            side_effect=mock_create,
+        ):
+            flow1 = make_flow("https://api.github.com/repos")
+            await manager.inject(flow1, "r1", "./script.sh", {}, 3600, "/config")
+            # Expire the cache
+            manager._cache["r1"].expires_at = time.monotonic() - 1
+
+            flow2 = make_flow("https://api.github.com/repos")
+            await manager.inject(flow2, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert call_count == 2
+
+    async def test_clear_all(self, manager: ExternalScriptManager):
+        """clear() evicts all cached results."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            flow = make_flow("https://api.github.com/repos")
+            await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert "r1" in manager._cache
+        manager.clear()
+        assert "r1" not in manager._cache
+
+    async def test_clear_specific_rule(self, manager: ExternalScriptManager):
+        """clear(rule_id) evicts only that rule."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            flow1 = make_flow("https://api.github.com/repos")
+            await manager.inject(flow1, "r1", "./script.sh", {}, 3600, "/config")
+            flow2 = make_flow("https://api.other.com/data")
+            await manager.inject(flow2, "r2", "./other.sh", {}, 3600, "/config")
+
+        manager.clear("r1")
+        assert "r1" not in manager._cache
+        assert "r2" in manager._cache
+
+    async def test_env_vars_passed(self, manager: ExternalScriptManager):
+        """Configured env vars are passed to the script."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+        captured_env = {}
+
+        async def mock_create(*args, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            return proc
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            side_effect=mock_create,
+        ):
+            flow = make_flow("https://api.github.com/repos")
+            await manager.inject(
+                flow,
+                "r1",
+                "./script.sh",
+                {"GITHUB_APP_ID": "12345", "CUSTOM_VAR": "val"},
+                3600,
+                "/config",
+            )
+
+        assert captured_env["GITHUB_APP_ID"] == "12345"
+        assert captured_env["CUSTOM_VAR"] == "val"
+
+    async def test_invalid_json_output(self, manager: ExternalScriptManager):
+        """Invalid JSON stdout → failure."""
+        flow = make_flow("https://api.github.com/repos")
+        proc = _make_proc_result(stdout="not json")
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            secrets = await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert secrets == []
+
+    async def test_missing_headers_key(self, manager: ExternalScriptManager):
+        """JSON without 'headers' dict → failure."""
+        flow = make_flow("https://api.github.com/repos")
+        output = json.dumps({"token": "abc"})
+        proc = _make_proc_result(stdout=output)
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            return_value=proc,
+        ):
+            secrets = await manager.inject(flow, "r1", "./script.sh", {}, 3600, "/config")
+
+        assert secrets == []
+
+    async def test_relative_script_path(self, manager: ExternalScriptManager):
+        """Relative script path resolved against config_dir."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+        captured_args: list[tuple] = []
+
+        async def mock_create(*args, **kwargs):
+            captured_args.append(args)
+            return proc
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            side_effect=mock_create,
+        ):
+            flow = make_flow("https://api.github.com/repos")
+            await manager.inject(flow, "r1", "./scripts/token.sh", {}, 3600, "/etc/proxy")
+
+        assert captured_args[0][0] == "/etc/proxy/scripts/token.sh"
+
+    async def test_absolute_script_path(self, manager: ExternalScriptManager):
+        """Absolute script path used as-is."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        )
+        proc = _make_proc_result(stdout=output)
+        captured_args: list[tuple] = []
+
+        async def mock_create(*args, **kwargs):
+            captured_args.append(args)
+            return proc
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            side_effect=mock_create,
+        ):
+            flow = make_flow("https://api.github.com/repos")
+            await manager.inject(flow, "r1", "/usr/local/bin/token.sh", {}, 3600, "/config")
+
+        assert captured_args[0][0] == "/usr/local/bin/token.sh"
+
+    async def test_failure_evicts_stale_cache(self, manager: ExternalScriptManager):
+        """Script failure after a cached result evicts the stale entry."""
+        output = json.dumps(
+            {
+                "headers": {"Authorization": "Bearer tok"},
+            }
+        )
+        good_proc = _make_proc_result(stdout=output)
+        bad_proc = _make_proc_result(returncode=1)
+
+        calls = 0
+
+        async def mock_create(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return good_proc if calls == 1 else bad_proc
+
+        with patch(
+            "auth_injection_proxy.injection.external_script.asyncio.create_subprocess_exec",
+            side_effect=mock_create,
+        ):
+            # First call succeeds
+            flow1 = make_flow("https://api.github.com/repos")
+            await manager.inject(flow1, "r1", "./script.sh", {}, 3600, "/config")
+            assert "r1" in manager._cache
+
+            # Expire the cache
+            manager._cache["r1"].expires_at = time.monotonic() - 1
+
+            # Second call fails → cache evicted
+            flow2 = make_flow("https://api.github.com/repos")
+            await manager.inject(flow2, "r1", "./script.sh", {}, 3600, "/config")
+            assert "r1" not in manager._cache

--- a/tests/unit/test_masking.py
+++ b/tests/unit/test_masking.py
@@ -4,6 +4,7 @@ from auth_injection_proxy.matching.models import (
     BasicAuth,
     BearerAuth,
     CredentialRule,
+    ExternalScriptAuth,
     HeaderAuth,
     OAuth2ClientCredentialsAuth,
     QueryParamAuth,
@@ -85,3 +86,31 @@ class TestMaskRule:
         masked = mask_rule(rule)
         assert masked["auth"]["param_name"] == "key"
         assert "***" in masked["auth"]["param_value"]
+
+    def test_external_script_env_masked(self):
+        """External script env values masked."""
+        rule = CredentialRule(
+            id="r1",
+            domain="d.com",
+            auth=ExternalScriptAuth(
+                type="external_script",
+                script="./token.sh",
+                env={"API_KEY": "secret-key", "APP_ID": "12345"},
+            ),
+        )
+        masked = mask_rule(rule)
+        assert masked["auth"]["script"] == "./token.sh"
+        assert masked["auth"]["env"] == {"API_KEY": "***", "APP_ID": "***"}
+
+    def test_external_script_empty_env(self):
+        """External script with no env → empty dict preserved."""
+        rule = CredentialRule(
+            id="r1",
+            domain="d.com",
+            auth=ExternalScriptAuth(
+                type="external_script",
+                script="./token.sh",
+            ),
+        )
+        masked = mask_rule(rule)
+        assert masked["auth"]["env"] == {}


### PR DESCRIPTION
## Summary

- Add new `external_script` auth type that delegates credential acquisition to any executable script
- Scripts output JSON with `headers` dict and optional `refresh_in` override; credentials are cached with per-rule locking
- Supports use cases like GitHub App installation tokens, Vault integrations, and other bespoke credential rotation

## Changes

- **Model**: `ExternalScriptAuth` added to discriminated union (`script`, `env`, `refresh_interval` fields)
- **Injection**: `ExternalScriptManager` with async subprocess execution, 30s timeout, double-checked locking cache (same pattern as `OAuth2TokenManager`)
- **Wiring**: Dispatch case in `injector.py`, manager instantiation in `addon.py`, cache clearing on hot-reload
- **Masking**: All env values masked in API responses
- **Docs**: Configuration guide, config example, README updated

## Test plan

- [x] 15 new unit tests for `ExternalScriptManager` (success, caching, expiry, failure, timeout, env vars, path resolution, cache eviction)
- [x] 2 new config parsing tests for `external_script` auth type
- [x] 2 new masking tests for `ExternalScriptAuth`
- [x] All 153 tests passing (20 new + 133 existing)
- [x] ruff lint clean, ruff format clean, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)